### PR TITLE
Documentation tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ pagemon command line options:
 
 * -h help
 * -a enable automatic zoom mode
-* -d delay in microseconds between refreshes, default 10000
+* -d delay in microseconds between refreshes, default 15000
 * -p specify process ID of process to monitor
 * -r read (page back in) pages at start
 * -t specify ticks between dirty page checks

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Pagemon is an interactive memory/page monitoring tool allowing one to browse the
 pagemon command line options:
 
 * -h help
+* -a enable automatic zoom mode
 * -d delay in microseconds between refreshes, default 10000
 * -p specify process ID of process to monitor
 * -r read (page back in) pages at start
@@ -15,3 +16,4 @@ pagemon command line options:
 
 * [viewing an ARM64 QEMU virtual machine running](https://www.youtube.com/embed/AS0s5nl_IXY)
 * [viewing page activity on a process that is sorting data](https://www.youtube.com/embed/Wq8YtKvC-Rw)
+* `pagemon -avp $(pgrep -la "COMMANDNAME" | fzf --exact --height=~70% --border | awk '{print $1}')`

--- a/pagemon.8
+++ b/pagemon.8
@@ -37,8 +37,8 @@ enable automatic zoom mode, this will change the zoom level to show
 the entire page map in the window, up to a maximum zoom level of 999.
 .TP
 .B \-d delay
-delay in microseconds between data refreshes, the default is 10,000
-microseconds (1/100th of a second).
+delay in microseconds between data refreshes, the default is 15,000
+microseconds (3/200th of a second).
 .TP
 .B \-h
 show help.


### PR DESCRIPTION
This cuts the boilerplate from the script I posted in #2 for the example section and fixes a doc mismatch..

- **README.md: Add automatic zoom line and convenience example**
- **Sync default delay value in documentation with code**
